### PR TITLE
Modification on intl.h and ayttm_tray.c

### DIFF
--- a/src/ayttm_tray.c
+++ b/src/ayttm_tray.c
@@ -105,18 +105,18 @@ void build_popup_menu()
 
 	popup_menu = gtk_menu_new();
 
-	APPEND_MENU_ITEM(sign_on_menu_item, N_("S_how/Hide Status Window"),
+	APPEND_MENU_ITEM(sign_on_menu_item, _("S_how/Hide Status Window"),
 		GTK_STOCK_FULLSCREEN, G_CALLBACK(icon_activate));
-	APPEND_MENU_ITEM(sign_on_menu_item, N_("Sign o_n All"),
+	APPEND_MENU_ITEM(sign_on_menu_item, _("Sign o_n All"),
 		GTK_STOCK_CONNECT, G_CALLBACK(eb_sign_on_all));
-	APPEND_MENU_ITEM(sign_off_menu_item, N_("Sign o_ff All"),
+	APPEND_MENU_ITEM(sign_off_menu_item, _("Sign o_ff All"),
 		GTK_STOCK_DISCONNECT, G_CALLBACK(eb_sign_off_all));
-	APPEND_MENU_ITEM(set_away_menu_item, N_("Set as _away"),
+	APPEND_MENU_ITEM(set_away_menu_item, _("Set as _away"),
 		"ayttm_away", G_CALLBACK(show_away_choicewindow));
-	APPEND_MENU_ITEM(prefs_menu_item, N_("_Preferences"),
+	APPEND_MENU_ITEM(prefs_menu_item, _("_Preferences"),
 		GTK_STOCK_PREFERENCES, G_CALLBACK(build_prefs_callback));
 	APPEND_MENU_ITEM(separator_menu_item, NULL, NULL, NULL);
-	APPEND_MENU_ITEM(quit_menu_item, N_("_Quit"),
+	APPEND_MENU_ITEM(quit_menu_item, _("_Quit"),
 		GTK_STOCK_QUIT, G_CALLBACK(ayttm_end_app));
 }
 

--- a/src/intl.h
+++ b/src/intl.h
@@ -7,7 +7,7 @@
 
 #ifdef ENABLE_NLS
 #  include <libintl.h>
-#  define _(String) gettext(String)
+#  define _(String) dgettext(PACKAGE,String)
 #  ifdef gettext_noop
 #    define N_(String) gettext_noop(String)
 #  else


### PR DESCRIPTION
On intl.h new action on dgttext

On ayttm_tray.c:
Removed N_ marks of gettext_noop, are not working, no function declared to translate the strings.
gettext_noop  mark the strings so that the xgettext program (see xgettext Invocation) can find them only, and is needed translate the string at runtime before printing them. 
